### PR TITLE
add mocking to the api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4154,6 +4154,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "10.15.0"
   },
   "scripts": {
-    "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files --ignore ./**/__tests__,./**/__mocks__",
+    "build": "rimraf __build__ && babel ./src -d ./__build__ --copy-files",
     "postbuild": "cp .env __build__",
     "predeploy:local": "npm run build",
     "deploy:local": "cd ./__build__ && functions-framework --target=graphEndpoint --port=8002 --verbose",
@@ -27,6 +27,7 @@
     "connect": "^3.7.0",
     "cors": "^2.8.5",
     "dotenv": "^8.1.0",
+    "faker": "^4.1.0",
     "graphql": "^14.5.8",
     "graphql-import": "^0.7.1",
     "graphql-scalars": "^1.0.4",

--- a/src/graphql/__mocks__/index.js
+++ b/src/graphql/__mocks__/index.js
@@ -1,0 +1,18 @@
+import faker from 'faker';
+
+import partner, { queries as partnerQueries } from './partner';
+import jobListing from './jobListing';
+
+const mocks = {
+  URL: () => faker.internet.url(),
+  PhoneNumber: () => faker.phone.phoneNumber(),
+  PostalCode: () => faker.address.zipCode(),
+  Partner: partner,
+  JobListing: jobListing,
+
+  Query: () => ({
+    ...partnerQueries(),
+  }),
+};
+
+export default () => mocks;

--- a/src/graphql/__mocks__/jobListing.js
+++ b/src/graphql/__mocks__/jobListing.js
@@ -1,0 +1,15 @@
+import uuid from 'uuid/v4';
+import faker from 'faker';
+
+const mockListing = () => ({
+  __typename: 'JobListing',
+  id: uuid(),
+  title: faker.lorem.sentence(),
+  description: faker.lorem.paragraph(),
+  role: faker.lorem.word(),
+});
+
+const mockQueries = () => ({});
+
+export default mockListing;
+export const queries = mockQueries;

--- a/src/graphql/__mocks__/partner.js
+++ b/src/graphql/__mocks__/partner.js
@@ -1,0 +1,31 @@
+import uuid from 'uuid/v4';
+import faker from 'faker';
+import moment from 'moment';
+
+const mockPartner = () => ({
+  __typename: 'Partner',
+  id: uuid(),
+  year: moment().year,
+  companyName: faker.company.companyName(),
+  goals: ['just', 'be', 'awesome'],
+  aboutUs: faker.company.catchPhrase(),
+  addressLineOne: faker.address.streetAddress(),
+  addressLineTwo: faker.address.secondaryAddress(),
+  city: faker.address.city(),
+  state: faker.address.state(),
+});
+
+const mockQueries = () => ({
+  partners: () => {
+    const results = [];
+
+    while (results.length < 40) {
+      results.push(mockPartner());
+    }
+
+    return results;
+  },
+});
+
+export default mockPartner;
+export const queries = mockQueries;

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,15 @@ const useSentry = async (req, res, next) => {
  *
  */
 const createUserContext = (req, res, next) => {
+  const enableMocking = () => {
+    if (!req.headers['that-enable-mocks']) return false;
+
+    const headerValues = req.headers['that-enable-mocks'].split(',');
+    const mocks = headerValues.map(i => i.trim().toUpperCase());
+
+    return !!mocks.includes('PARTNERS');
+  };
+
   req.userContext = {
     locale: req.headers.locale,
     authToken: req.headers.authorization,
@@ -51,6 +60,7 @@ const createUserContext = (req, res, next) => {
       ? req.headers['correlation-id']
       : uuid(),
     sentry: Sentry,
+    enableMocking: enableMocking(),
     firestore: new Firestore(),
   };
 
@@ -59,7 +69,10 @@ const createUserContext = (req, res, next) => {
 
 const apiHandler = async (req, res) => {
   try {
-    const graphServer = apolloGraphServer(createConfig());
+    const graphServer = apolloGraphServer(
+      createConfig(),
+      req.userContext.enableMocking,
+    );
     const graphApi = graphServer.createHandler({
       cors: {
         origin: '*',


### PR DESCRIPTION
enables mocking on the api.

to enable pass header token: `that-enable-mocks = partners`

partially closes [ch1701]
Story details: https://app.clubhouse.io/thatconference/story/1701