### PR TITLE
adds a slug property

### DIFF
--- a/src/graphql/typeDefs/dataTypes/partner.graphql
+++ b/src/graphql/typeDefs/dataTypes/partner.graphql
@@ -8,7 +8,7 @@ type Partner @key(fields: "id") {
   website: URL
   goals: [String]
 
-  slug: URL
+  slug: String
   heroImage: URL
   aboutUs: String
 

--- a/src/graphql/typeDefs/dataTypes/partner.graphql
+++ b/src/graphql/typeDefs/dataTypes/partner.graphql
@@ -8,6 +8,7 @@ type Partner @key(fields: "id") {
   website: URL
   goals: [String]
 
+  slug: URL
   heroImage: URL
   aboutUs: String
 

--- a/src/graphql/typeDefs/dataTypes/partnerInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/partnerInput.graphql
@@ -6,6 +6,7 @@ input PartnerInput {
   website: URL
   goals: [String]
 
+  slug: URL
   heroImage: URL
   aboutUs: String
 

--- a/src/graphql/typeDefs/dataTypes/partnerInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/partnerInput.graphql
@@ -6,7 +6,7 @@ input PartnerInput {
   website: URL
   goals: [String]
 
-  slug: URL
+  slug: String
   heroImage: URL
   aboutUs: String
 


### PR DESCRIPTION
adds a slug to a partner for url routing.

@kburnell and @saragibby do we really want the slug to ever change? I'm thinking we might want to only have it on the create partner and not the update. thoughts?

FWIW it's there on update now. 

closes #8 