### PR TITLE
Partner us path auth changed partners to members

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-partners",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "that's partners api",
   "main": "index.js",
   "engines": {

--- a/src/graphql/typeDefs/mutations/partners.graphql
+++ b/src/graphql/typeDefs/mutations/partners.graphql
@@ -7,7 +7,7 @@ type PartnersMutation {
   favoriting(findBy: FindPartnerInput!): PartnerFavoritingMutation
     @auth(requires: "members")
   "Partner mutation for a partner by a partner"
-  us: UsPartnerMutation @auth(requires: "partners")
+  us: UsPartnerMutation @auth(requires: "members")
   "Partner mutation for a partner by a member"
   me(findBy: FindPartnerInput!): MePartnerMutation @auth(requires: "members")
 }

--- a/src/graphql/typeDefs/mutations/usPartner.graphql
+++ b/src/graphql/typeDefs/mutations/usPartner.graphql
@@ -1,4 +1,4 @@
 type UsPartnerMutation {
   "Lead mutations for focused partner"
-  leads: UsPartnerLeadsMutation @auth(requires: "partners")
+  leads: UsPartnerLeadsMutation @auth(requires: "members")
 }

--- a/src/graphql/typeDefs/mutations/usPartnerLeads.graphql
+++ b/src/graphql/typeDefs/mutations/usPartnerLeads.graphql
@@ -1,4 +1,4 @@
 type UsPartnerLeadsMutation {
   "Add a new lead"
-  add(lead: PartnerLeadCreateInput): NewLeadResult!
+  add(lead: PartnerLeadCreateInput): NewLeadResult! @auth(requires: "members")
 }

--- a/src/graphql/typeDefs/queries/partners.graphql
+++ b/src/graphql/typeDefs/queries/partners.graphql
@@ -6,5 +6,5 @@ type PartnersQuery {
   "Partner data in scope of logged in member"
   me: MePartnerQuery @auth(requires: "members")
   "Partner-specific data, leads, etc."
-  us: UsPartnerQuery @auth(requires: "partners")
+  us: UsPartnerQuery @auth(requires: "members")
 }

--- a/src/graphql/typeDefs/queries/usPartner.graphql
+++ b/src/graphql/typeDefs/queries/usPartner.graphql
@@ -1,3 +1,3 @@
 type UsPartnerQuery {
-  leads: UsPartnerLeadsQuery @auth(requires: "partners")
+  leads: UsPartnerLeadsQuery @auth(requires: "members")
 }

--- a/src/graphql/typeDefs/queries/usPartnerLeads.graphql
+++ b/src/graphql/typeDefs/queries/usPartnerLeads.graphql
@@ -1,3 +1,3 @@
 type UsPartnerLeadsQuery {
-  all: [PartnerLeadView]! @auth(requires: "partners")
+  all: [PartnerLeadView]! @auth(requires: "members")
 }


### PR DESCRIPTION
Us path permissions checked at database level ensuring that member has partner id set on their profile and that they are set to a particular partner. 
members/<id>/activePartnerId
partners/<id>/members/<id>