### PR TITLE
refactor: member-generated lead email event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-partners",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "THAT Conference partners service",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
## v4.3.1

Refactor member-generated partner lead email
Primary contact and member both on To line
If the primary contact isn't set, the email will still be sent. 
Uses Postmark template, `lead-member-generated`